### PR TITLE
feat(utils): make tz_today timezone aware

### DIFF
--- a/ai_django_core/utils/date.py
+++ b/ai_django_core/utils/date.py
@@ -31,7 +31,7 @@ def tz_today(str_format=None):
     :return:
     """
     if settings.USE_TZ:
-        date = timezone.now().date()
+        date = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
     else:
         date = datetime.datetime.now().date()
 

--- a/tests/test_utils_date.py
+++ b/tests/test_utils_date.py
@@ -4,6 +4,7 @@ import datetime
 import pytz
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.utils.timezone import make_aware
 from freezegun import freeze_time
 
 from ai_django_core.utils.date import date_month_delta, get_start_and_end_date_from_calendar_week, tz_today, \
@@ -84,10 +85,11 @@ class DateUtilTest(TestCase):
             date_month_delta(start_date, end_date)
 
     @override_settings(USE_TZ=True)
-    def test_tz_today_as_object_tz_active(self):
-        frozen_date = datetime.datetime(year=2019, month=9, day=19, hour=10)
+    def test_tz_today_as_object_tz_active_is_tz_aware(self):
+        frozen_date = make_aware(datetime.datetime(year=2019, month=9, day=19))
         with freeze_time(frozen_date):
-            self.assertEqual(tz_today(), frozen_date.date())
+            self.assertTrue(isinstance(tz_today(), datetime))
+            self.assertEqual(tz_today(), frozen_date)
 
     def test_tz_today_as_object_tz_not_active(self):
         frozen_date = datetime.datetime(year=2019, month=9, day=19, hour=10)


### PR DESCRIPTION
tz_today returns a naive date object instead of a timezone aware datetime object
Fixed the test for the newly timezone aware tz_today util

For reference, see the Django source code about this problem:
https://github.com/django/django/blob/5de12a369a7b2231e668e0460c551c504718dbf6/django/db/models/fields/__init__.py#L1344